### PR TITLE
Support shell script highlighting with BashSupport Pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support shell script highlighting with BashSupport Pro in addition to the existing support for the JetBrains Shell plugin.
+  CI Aid for GitLab can be installed without the JetBrains Shell or BashSupport Pro plugins. Highlighting of shell scripts
+  will be available as soon as one of the plugins is enabled.
+
 ## [1.4.0] - 2025-05-03
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ platformVersion = 2025.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
-platformPlugins =
+platformPlugins = pro.bashsupport:4.6.3.251
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = org.jetbrains.plugins.yaml, org.jetbrains.plugins.terminal, com.intellij.modules.json, com.jetbrains.sh
 

--- a/src/main/java/com/github/deeepamin/ciaid/services/injectors/BashSupportProGitlabCIYamlScriptInjector.java
+++ b/src/main/java/com/github/deeepamin/ciaid/services/injectors/BashSupportProGitlabCIYamlScriptInjector.java
@@ -1,0 +1,7 @@
+package com.github.deeepamin.ciaid.services.injectors;
+
+public class BashSupportProGitlabCIYamlScriptInjector extends AbstractGitlabCIYamlScriptInjector {
+  protected BashSupportProGitlabCIYamlScriptInjector() {
+    super("BashSupport Pro Shell Script");
+  }
+}

--- a/src/main/java/com/github/deeepamin/ciaid/services/injectors/JetBrainsShellGitlabCIYamlScriptInjector.java
+++ b/src/main/java/com/github/deeepamin/ciaid/services/injectors/JetBrainsShellGitlabCIYamlScriptInjector.java
@@ -1,0 +1,7 @@
+package com.github.deeepamin.ciaid.services.injectors;
+
+public class JetBrainsShellGitlabCIYamlScriptInjector extends AbstractGitlabCIYamlScriptInjector {
+  protected JetBrainsShellGitlabCIYamlScriptInjector() {
+    super("Shell Script");
+  }
+}

--- a/src/main/resources/META-INF/plugin-bashsupport-pro.xml
+++ b/src/main/resources/META-INF/plugin-bashsupport-pro.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <multiHostInjector
+                implementation="com.github.deeepamin.ciaid.services.injectors.BashSupportProGitlabCIYamlScriptInjector"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin-shell.xml
+++ b/src/main/resources/META-INF/plugin-shell.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <multiHostInjector order="first"
+                           implementation="com.github.deeepamin.ciaid.services.injectors.JetBrainsShellGitlabCIYamlScriptInjector"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,10 +8,10 @@
     <depends>org.jetbrains.plugins.yaml</depends>
     <depends>com.intellij.modules.json</depends>
     <depends>org.jetbrains.plugins.terminal</depends>
-    <resource-bundle>messages.GitlabCIAid</resource-bundle>
-
     <depends optional="true" config-file="plugin-shell.xml">com.jetbrains.sh</depends>
     <depends optional="true" config-file="plugin-bashsupport-pro.xml">pro.bashsupport</depends>
+
+    <resource-bundle>messages.GitlabCIAid</resource-bundle>
 
     <extensions defaultExtensionNs="com.intellij">
         <psi.referenceContributor language="yaml" implementation="com.github.deeepamin.ciaid.services.contributors.GitlabCIYamlReferenceContributor"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,14 +8,15 @@
     <depends>org.jetbrains.plugins.yaml</depends>
     <depends>com.intellij.modules.json</depends>
     <depends>org.jetbrains.plugins.terminal</depends>
-    <depends>com.jetbrains.sh</depends>
     <resource-bundle>messages.GitlabCIAid</resource-bundle>
+
+    <depends optional="true" config-file="plugin-shell.xml">com.jetbrains.sh</depends>
+    <depends optional="true" config-file="plugin-bashsupport-pro.xml">pro.bashsupport</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <psi.referenceContributor language="yaml" implementation="com.github.deeepamin.ciaid.services.contributors.GitlabCIYamlReferenceContributor"/>
         <postStartupActivity implementation="com.github.deeepamin.ciaid.services.GitlabCIYamlPostStartup"/>
         <completion.contributor language="yaml" implementationClass="com.github.deeepamin.ciaid.services.contributors.GitlabCIYamlCodeContributor"/>
-        <multiHostInjector implementation="com.github.deeepamin.ciaid.services.injectors.GitlabCIYamlScriptInjector"/>
         <annotator language="yaml" implementationClass="com.github.deeepamin.ciaid.services.annotators.GitlabCIYamlAnnotator"/>
         <fileType name="Gitlab CI YAML" implementationClass="com.github.deeepamin.ciaid.language.GitlabCIYamlFileType" patterns="*.gitlab-ci.yml;*.gitlab-ci.yaml" order="first" fileNames=".gitlab-ci.yml;.gitlab-ci.yaml"/>
         <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>


### PR DESCRIPTION
Closes https://github.com/deeepamin/gitlab-ci-aid/issues/55

It's an alternative to JetBrains Shell script support. Both implementations are now defined in optional dependencies.

There were several ways to implement this PR.
I chose an implementation with the least amount of changes and without a build-time dependency to avoid complicating the setup.

Testing with BashSupport Pro would only be easy to add with a multi-module build and 2.5.1 of `org.jetbrains.intellij.platform`, which would allow to add a build-time dependency on BashSupport Pro without constantly updating its version: https://github.com/JetBrains/intellij-platform-gradle-plugin/commit/c51f3c3170f64b09958a4d4865462cdd8f5ed0f1